### PR TITLE
authenticate middleware redirect to default login page issue fixed

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -47,7 +47,7 @@ Route::group(['as' => 'flowcms::', 'namespace' => '\Flowcms\Flowcms\Controllers'
     // Contact us
     Route::post('/contact', 'ContactController@store')->name('contact.store')->middleware(\Spatie\Honeypot\ProtectAgainstSpam::class);
 
-    Route::group(['middleware' => 'auth'], function () {
+    Route::group(['middleware' => 'auth.flowcms'], function () {
         // Dashboard
         Route::get('/dashboard', 'DashboardController@index')->name('dashboard');
 

--- a/src/Controllers/Auth/LoginController.php
+++ b/src/Controllers/Auth/LoginController.php
@@ -3,7 +3,6 @@
 namespace Flowcms\Flowcms\Controllers\Auth;
 
 use Illuminate\Routing\Controller;
-use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
 class LoginController extends Controller
@@ -21,12 +20,10 @@ class LoginController extends Controller
 
     use AuthenticatesUsers;
 
-    /**
-     * Where to redirect users after login.
-     *
-     * @var string
-     */
-    protected $redirectTo = '/dashboard';
+    public function redirectTo()
+    {
+        return route('flowcms::dashboard');
+    }
 
     /**
      * Create a new controller instance.

--- a/src/FlowcmsServiceProvider.php
+++ b/src/FlowcmsServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
 use Flowcms\Flowcms\Middleware\HtmlMinifier;
+use Flowcms\Flowcms\Middleware\AuthenticateWithFlowcms;
 
 class FlowcmsServiceProvider extends ServiceProvider
 {
@@ -49,6 +50,7 @@ class FlowcmsServiceProvider extends ServiceProvider
         * Optional methods to load your package assets
          */
         $router->middlewareGroup('HtmlMinifier', [HtmlMinifier::class]);
+        $router->middlewareGroup('auth.flowcms', [AuthenticateWithFlowcms::class]);
 
         $this->loadViewsFrom(__DIR__ . '/../resources/views', 'flowcms');
         $this->loadBladeDirectives();

--- a/src/Middleware/AuthenticateWithFlowcms.php
+++ b/src/Middleware/AuthenticateWithFlowcms.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Flowcms\Flowcms\Middleware;
+
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
+
+class AuthenticateWithFlowcms extends Middleware
+{
+    /**
+     * Get the path the user should be redirected to when they are not authenticated.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|null
+     */
+    protected function redirectTo($request)
+    {
+        if (!$request->expectsJson()) {
+            return route('flowcms::login');
+        }
+    }
+}


### PR DESCRIPTION
authenticate middleware redirect to default login page issue fixed
- added a new middleware group named `auth.flowcms`
- made the flowcms routes to use the above middleware
- redirect to login issue fixed while session expired